### PR TITLE
Handle exception in AsseticInjectorTokenParser

### DIFF
--- a/Twig/AsseticInjectorTokenParser.php
+++ b/Twig/AsseticInjectorTokenParser.php
@@ -72,7 +72,11 @@ class AsseticInjectorTokenParser extends BaseAsseticTokenParser
                 // this happens when the filename isn't a Bundle:* url
                 // but an absolute path instead
             }
-            $bundle = $templateRef ? $templateRef->get('bundle') : null;
+            try {
+                $bundle = $templateRef ? $templateRef->get('bundle') : null;
+            } catch (\InvalidArgumentException $e) {
+                $bundle = null;
+            }
             if ($bundle && !in_array($bundle, $this->enabledBundles)) {
                 throw new InvalidBundleException($bundle, "the {% {$this->getTag()} %} tag", $templateRef->getLogicalName(), $this->enabledBundles);
             }


### PR DESCRIPTION
I got following error when calling the `translation:update` command:

    [InvalidArgumentException]
    The template does not support the "bundle" parameter.

The AsseticInjectorTokenParser calls `$templateRef->get('bundle')` to see if the bundle in question is configured in the allowedBundles parameter.

One of my views extends `::base.html.twig` so I figure this template would not have a bundle parameter, and therefor the exception gets thrown.

As far as I can tell, AsseticInjectorBundle does not break if it comes across such a template, therefor a silent handling of the exception should suffice...